### PR TITLE
remove protected $uri property

### DIFF
--- a/src/CILogViewer.php
+++ b/src/CILogViewer.php
@@ -109,7 +109,7 @@ class CILogViewer {
 
         if(!is_null($request->getGet("del"))) {
             $this->deleteFiles(base64_decode($request->getGet("del")));
-            $uri = \Config\Services::request()->uri->getPath();
+            $uri = \Config\Services::request()->getPath();
             return redirect()->to('/'.$uri);
         }
 


### PR DESCRIPTION
In v4.5.0 the property IncomingRequest::$uri is protected, which cannot be acessed anymore.

PR: https://github.com/codeigniter4/CodeIgniter4/pull/8067